### PR TITLE
Enable hexa mesh with transfinite but no recombine in z dir

### DIFF
--- a/src/generators.jl
+++ b/src/generators.jl
@@ -449,6 +449,7 @@ end
         n_partitions = 0,
         write_geo = false,
         transfinite_lines = true,
+        recombine_z = (transfinite || (type == :hexa),
         lc = 1e-1,
         kwargs...,
     )
@@ -476,7 +477,7 @@ function gen_hexa_mesh(
     write_geo = false,
     transfinite = (type == :hexa),
     transfinite_lines = (type == :hexa),
-    recombine_z = (transfinite || isHexa),
+    recombine_z = (transfinite || (type == :hexa),
     lc = 1e-1,
     kwargs...,
 )

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -476,6 +476,7 @@ function gen_hexa_mesh(
     write_geo = false,
     transfinite = (type == :hexa),
     transfinite_lines = (type == :hexa),
+    recombine_z = (transfinite || isHexa),
     lc = 1e-1,
     kwargs...,
 )
@@ -508,8 +509,7 @@ function gen_hexa_mesh(
 
     # Extrusion
     nlayers = (transfinite || isHexa || transfinite_lines) ? [nz - 1] : []
-    recombine = (transfinite || isHexa)
-    out = gmsh.model.geo.extrude([(2, ABCD)], 0, 0, lz, nlayers, [], recombine)
+    out = gmsh.model.geo.extrude([(2, ABCD)], 0, 0, lz, nlayers, [], recombine_z)
 
     # Identification
     zmin = ABCD

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -449,7 +449,7 @@ end
         n_partitions = 0,
         write_geo = false,
         transfinite_lines = true,
-        recombine_z = (transfinite || (type == :hexa),
+        recombine_z = (transfinite || (type == :hexa)),
         lc = 1e-1,
         kwargs...,
     )
@@ -477,7 +477,7 @@ function gen_hexa_mesh(
     write_geo = false,
     transfinite = (type == :hexa),
     transfinite_lines = (type == :hexa),
-    recombine_z = (transfinite || (type == :hexa),
+    recombine_z = (transfinite || (type == :hexa)),
     lc = 1e-1,
     kwargs...,
 )


### PR DESCRIPTION
Enable hexa mesh with transfinite but no recombine in z dir. This is usefull to build **quickly** a mesh of a cube field with tetra.