### PR TITLE
Fix one cell mesh

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -107,7 +107,7 @@ function _read_msh(spaceDim::Int, verbose::Bool)
 
     # Build cell->node connectivity (with Gmsh internal numbering convention)
     c2n_gmsh = Bcube.Connectivity(
-        Int[nnodes(k) for k in reduce(vcat, celltypes)],
+        map(nnodes, celltypes),
         Int[glo2loc_node_indices[k] for k in reduce(vcat, nodeTags)],
     )
 

--- a/test/test_read.jl
+++ b/test/test_read.jl
@@ -170,4 +170,12 @@
         @test Bcube.get_zone_element_indices(mesh, "ALUMINIUM") == [1]
         @test Bcube.get_zone_element_indices(mesh, "WATER") == collect(2:26)
     end
+
+    @testset "one-cell-mesh" begin
+        path = joinpath(tempdir, "mesh.msh")
+        BcubeGmsh.gen_hexa_mesh(path, :hexa; nx = 2, ny = 2, nz = 2)
+        mesh = read_mesh(path)
+        @test ncells(mesh) == 1
+        @test nnodes(mesh) == 8
+    end
 end


### PR DESCRIPTION
The package was not able to read meshes with only one cell. It is now fixed.

Rq: using `nnodes.(celltypes)` instead of `map(nnodes, celltypes)` also works.